### PR TITLE
New version of generate.py and affordances JSON scheme

### DIFF
--- a/tests/wot_coap_generation/config/wot_td/.coap_affordances.json
+++ b/tests/wot_coap_generation/config/wot_td/.coap_affordances.json
@@ -5,13 +5,14 @@
     },
     "actions": {
         "toggle": {
-            "url": "/led/toggle",
-            "handler": {
-                "file": "toggle.c",
-                "name": "_led_toggle_handler",
-                "multipleUsage": false
-            },
-            "method": "POST",
+            "forms": [
+                {
+                    "handler_file": "toggle.c",
+                    "handler_function": "_led_toggle_handler",
+                    "href": "/led/toggle", 
+                    "cov:methodName": "POST"
+                }
+            ],
             "titles": {
                 "de": "Deutscher Titel",
                 "en": "English title"

--- a/tests/wot_coap_generation/config/wot_td/.coap_affordances.json
+++ b/tests/wot_coap_generation/config/wot_td/.coap_affordances.json
@@ -3,9 +3,8 @@
     },
     "events": {
     },
-    "actions": [
-        {
-            "name": "toggle",
+    "actions": {
+        "toggle": {
             "url": "/led/toggle",
             "handler": {
                 "file": "toggle.c",
@@ -44,5 +43,5 @@
                 }
             }
         }
-    ]
+    }
 }

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -54,37 +54,37 @@ def validate_thing_json(thingJson):
     assert thingJson['titles'], "ERROR: name in thing.json missing"
     assert thingJson['defaultLang'], "ERROR: name in thing.json missing"
 
-def validate_unique_name(name, jsons, propName):
+def validate_unique_name(name, jsons, affordance_name):
     count = 0
     for j in jsons:
-        for aff in j[propName]:
-            if aff[name] == name:
+        for affordance in j[affordance_name].values():
+            if affordance[name] == name:
                 count += 1
             assert not(count > 1), "ERROR: Each coap affordance has to be unique"
 
 def validate_coap_affordances(coapJsons):
     for coapJson in coapJsons:
         properties = coapJson['properties']
-        for prop in properties:
+        for prop in properties.values():
             name = prop['name']
             validate_unique_name(name, coapJsons, 'properties')
 
         events = coapJson['events']
-        for event in events:
+        for event in events.values():
             name = event['name']
             validate_unique_name(name, coapJsons, 'events')
 
         actions = coapJson['actions']
-        for action in actions:
+        for action in actions.values():
             name = action['name']
             validate_unique_name(name, coapJsons, 'actions')
 
 def find_all_coap_methods(handlerName, affName, coapJsons):
     methods = []
     for coapJson in coapJsons:
-        for aff in coapJson[affName]:
-            if aff['handler']['name'] == handlerName:
-                methods.append(aff['method'])
+        for affordance in coapJson[affName].values():
+            if affordance['handler']['name'] == handlerName:
+                methods.append(affordance['method'])
     return methods
 
 def write_coap_resources(coapResources):
@@ -105,12 +105,14 @@ def write_coap_resources(coapResources):
 def generate_coap_resources():
     coapRessources = []
     for coapJson in coapJsons:
-        properties = coapJson['properties']
-        for prop in properties:
-            handler = prop['handler']
-            if 0 == len(filter(lambda x: handler == x, coapRessources)):
-                url = prop['url']
-                methods = find_all_coap_methods(handler, 'properties', coapJsons)
+        affordance_types = ['properties', 'actions', 'events']
+        for affordance_type in affordance_types:
+            affordances = coapJson[affordance_type].values()
+            for affordance in affordances:
+                handler = affordance['handler']
+                # if 0 == len(filter(lambda x: handler == x, coapRessources)):
+                url = affordance['url']
+                methods = find_all_coap_methods(handler, affordance_type, coapJsons)
                 coapRessources.append({
                     'url': url,
                     'handler': handler,

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -24,6 +24,16 @@ parser.add_argument('--board', help='Define used board')
 parser.add_argument('--saul', action='store_true', help='Define if WoT TD SAUL is used')
 parser.add_argument('--security', help='Define what security is used')
 
+def dict_raise_on_duplicates(ordered_pairs):
+    """Reject duplicate keys."""
+    d = {}
+    for k, v in ordered_pairs:
+        if k in d:
+           raise ValueError("duplicate key: %r" % (k,))
+        else:
+           d[k] = v
+    return d
+
 def add_content(content):
     global result
     result += content
@@ -131,8 +141,8 @@ if __name__ == '__main__':
     coapAffordances = currentDirectory + "/config/wot_td/.coap_affordances.json"
     try:
         f = open(coapAffordances)
-        coapJson = json.loads(f.read())
         validate_coap_affordances(coapJsons)
+        coapJson = json.loads(f.read(), object_pairs_hook=dict_raise_on_duplicates)
         coapJsons.append(coapJson)
     except IOError:
         print("INFO: Coap definition in " + coapAffordances + " not present")

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -84,13 +84,17 @@ def generate_coap_resources():
     for coap_json in coap_jsons:
         for affordance_type in AFFORDANCE_TYPES:
             for affordance_name, affordance in coap_json[affordance_type].items():
-                for defined_affordances in multiple_usage.values():
-                    assert affordance_name not in defined_affordances, "ERROR: Each coap affordance has to be unique"
+                assert_unique_affordance(affordance_name)
                 multiple_usage[affordance_type].append(affordance_name)
                 forms = affordance["forms"]
                 resources = extract_coap_resources(forms)
                 coap_resources.extend(resources)
     write_coap_resources(coap_resources)
+
+
+def assert_unique_affordance(affordance_name: str):
+    for defined_affordances in multiple_usage.values():
+        assert affordance_name not in defined_affordances, "ERROR: Each coap affordance has to be unique"
 
 
 def extract_coap_resources(resources: list) -> list:

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -128,28 +128,28 @@ if __name__ == '__main__':
     assert args.board, "ERROR: Argument board has to be defined"
     assert args.security, "ERROR: Argument security has to be defined"
 
-    thing_definiton = current_directory + "/config/wot_td/.thing.json"
+    thing_definiton = f"{current_directory}/config/wot_td/.thing.json"
     try:
         f = open(thing_definiton)
         thingJson = json.loads(f.read())
     except IOError:
-        print("ERROR: Thing definition in " + thing_definiton + " is missing")
+        print(f"ERROR: Thing definition in {thing_definiton} is missing")
         sys.exit(0)
     except json.decoder.JSONDecodeError:
-        print("ERROR: json in " + thing_definiton + " is not valid")
+        print(f"ERROR: json in {thing_definiton} is not valid")
         sys.exit(0)
     finally:
         f.close()
-    
-    coap_affordances = current_directory + "/config/wot_td/.coap_affordances.json"
+
+    coap_affordances = f"{current_directory}/config/wot_td/.coap_affordances.json"
     try:
         f = open(coap_affordances)
         coap_json = json.loads(f.read(), object_pairs_hook=dict_raise_on_duplicates)
         coap_jsons.append(coap_json)
     except IOError:
-        print("INFO: Coap definition in " + coap_affordances + " not present")
+        print(f"INFO: Coap definition in {coap_affordances} not present")
     except json.decoder.JSONDecodeError:
-        print("ERROR: json in " + coap_affordances + " is not valid")
+        print(f"ERROR: json in {coap_affordances} is not valid")
         sys.exit(0)
     finally:
         f.close()

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -52,6 +52,7 @@ def write_to_c_file(content):
 
 
 def validate_coap_json(coap_jsons):
+    # TODO: Add actual validator for (different types of) affordances
     assert coap_jsons['name'], "ERROR: name in coap_affordances.json missing"
     assert coap_jsons['url'], "ERROR: url in coap_affordances.json missing"
     assert coap_jsons['handler'], "ERROR: handler in coap_affordances.json missing"
@@ -59,6 +60,7 @@ def validate_coap_json(coap_jsons):
 
 
 def validate_thing_json(thing_json):
+    # TODO: Expand thing validation
     assert thing_json['titles'], "ERROR: name in thing.json missing"
     assert thing_json['defaultLang'], "ERROR: name in thing.json missing"
 

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -84,8 +84,8 @@ def generate_coap_resources():
     for coap_json in coap_jsons:
         for affordance_type in AFFORDANCE_TYPES:
             for affordance_name, affordance in coap_json[affordance_type].items():
-                assert affordance_name not in multiple_usage[
-                    affordance_type], "ERROR: Each coap affordance has to be unique"
+                for defined_affordances in multiple_usage.values():
+                    assert affordance_name not in defined_affordances, "ERROR: Each coap affordance has to be unique"
                 multiple_usage[affordance_type].append(affordance_name)
                 forms = affordance["forms"]
                 resources = extract_coap_resources(forms)

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -56,39 +56,6 @@ def validate_thing_json(thing_json):
     assert thing_json['titles'], "ERROR: name in thing.json missing"
     assert thing_json['defaultLang'], "ERROR: name in thing.json missing"
 
-def validate_unique_name(name, jsons, affordance_name):
-    count = 0
-    for j in jsons:
-        for affordance in j[affordance_name].values():
-            if affordance[name] == name:
-                count += 1
-            assert not(count > 1), "ERROR: Each coap affordance has to be unique"
-
-def validate_coap_affordances(coap_jsons):
-    # FIXME: Actual validation needs to be implemented
-    for coap_json in coap_jsons:
-        properties = coap_json['properties']
-        for prop in properties.values():
-            name = prop['name']
-            validate_unique_name(name, coap_jsons, 'properties')
-
-        events = coapJson['events']
-        for event in events.values():
-            name = event['name']
-            validate_unique_name(name, coap_jsons, 'events')
-
-        actions = coapJson['actions']
-        for action in actions.values():
-            name = action['name']
-            validate_unique_name(name, coap_jsons, 'actions')
-
-def find_all_coap_methods(handlerName, affordance_name, coap_jsons):
-    methods = []
-    for coapJson in coap_jsons:
-        for affordance in coapJson[affordance_name].values():
-            if affordance['handler']['name'] == handlerName:
-                methods.append(affordance['method'])
-    return methods
 
 def write_coap_resources(coap_resources):
     add_content("const coap_resource_t _coap_resources[] = {\n")

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -102,7 +102,7 @@ def write_coap_resources(coapResources):
 
     add_content("\n};")
 
-def generate_coap_resouces():
+def generate_coap_resources():
     coapRessources = []
     for coapJson in coapJsons:
         properties = coapJson['properties']
@@ -151,5 +151,5 @@ if __name__ == '__main__':
         sys.exit(0)
     finally:
         f.close()
-    generate_coap_resouces()
+    generate_coap_resources()
     print(result)

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -63,6 +63,7 @@ def validate_unique_name(name, jsons, affordance_name):
             assert not(count > 1), "ERROR: Each coap affordance has to be unique"
 
 def validate_coap_affordances(coapJsons):
+    # FIXME: Actual validation needs to be implemented
     for coapJson in coapJsons:
         properties = coapJson['properties']
         for prop in properties.values():
@@ -143,7 +144,6 @@ if __name__ == '__main__':
     coapAffordances = currentDirectory + "/config/wot_td/.coap_affordances.json"
     try:
         f = open(coapAffordances)
-        validate_coap_affordances(coapJsons)
         coapJson = json.loads(f.read(), object_pairs_hook=dict_raise_on_duplicates)
         coapJsons.append(coapJson)
     except IOError:

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -23,22 +23,26 @@ coap_affordances = {
 
 parser = argparse.ArgumentParser(description='Web of Things helper script')
 parser.add_argument('--board', help='Define used board')
-parser.add_argument('--saul', action='store_true', help='Define if WoT TD SAUL is used')
+parser.add_argument('--saul', action='store_true',
+                    help='Define if WoT TD SAUL is used')
 parser.add_argument('--security', help='Define what security is used')
+
 
 def dict_raise_on_duplicates(ordered_pairs):
     """Reject duplicate keys."""
     d = {}
     for k, v in ordered_pairs:
         if k in d:
-           raise ValueError("duplicate key: %r" % (k,))
+            raise ValueError("duplicate key: %r" % (k,))
         else:
-           d[k] = v
+            d[k] = v
     return d
+
 
 def add_content(content):
     global result
     result += content
+
 
 def write_to_c_file(content):
     global result
@@ -46,11 +50,13 @@ def write_to_c_file(content):
     f.write(result)
     f.close()
 
+
 def validate_coap_json(coap_jsons):
     assert coap_jsons['name'], "ERROR: name in coap_affordances.json missing"
     assert coap_jsons['url'], "ERROR: url in coap_affordances.json missing"
     assert coap_jsons['handler'], "ERROR: handler in coap_affordances.json missing"
     assert coap_jsons['method'], "ERROR: method in coap_affordances.json missing"
+
 
 def validate_thing_json(thing_json):
     assert thing_json['titles'], "ERROR: name in thing.json missing"
@@ -138,7 +144,8 @@ if __name__ == '__main__':
     coap_affordances = f"{current_directory}/config/wot_td/.coap_affordances.json"
     try:
         f = open(coap_affordances)
-        coap_json = json.loads(f.read(), object_pairs_hook=dict_raise_on_duplicates)
+        coap_json = json.loads(
+            f.read(), object_pairs_hook=dict_raise_on_duplicates)
         coap_jsons.append(coap_json)
     except IOError:
         print(f"INFO: Coap definition in {coap_affordances} not present")

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -131,7 +131,8 @@ if __name__ == '__main__':
     thing_definiton = f"{current_directory}/config/wot_td/.thing.json"
     try:
         f = open(thing_definiton)
-        thingJson = json.loads(f.read())
+        thing_json = json.loads(f.read())
+        validate_thing_json(thing_json)
     except IOError:
         print(f"ERROR: Thing definition in {thing_definiton} is missing")
         sys.exit(0)


### PR DESCRIPTION
(Hopefully) fixed the schema in `.coap_affordances.json` (is now more similar to the schema used in the acutal thing descriptions), added functions to automatically determine duplicate keys and extract method names and other information from the defined `forms`. 

Some assertions for a correct defintion of the affordances and the meta information JSON files are already being made -- there is, however, still much room for further validation of the input files.