### PR TITLE
Further foundational work on the generate.py script

### DIFF
--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -13,6 +13,7 @@ THING_FILES = [".thing.json", ]
 SEPERATOR = "\n\n"
 INDENT = "    "
 COAP_LISTENER_NAME = "_coap_listener"
+COAP_LINK_PARAMS_NAME = "_wot_link_params"
 
 DEFAULT_DEPENDENCIES = ['<stdint.h>', '<stdio.h>', '<stdlib.h>',
                         '<string.h>', '"net/gcoap.h"', '"od.h"', '"fmt.h"', ]
@@ -199,6 +200,22 @@ def generate_coap_handlers(coap_resources: list) -> str:
     return SEPERATOR.join(handlers)
 
 
+def generate_coap_link_param(coap_resource):
+    return "NULL"
+
+
+def generate_coap_link_params(coap_resources: list):
+    result = f"static const char *{COAP_LINK_PARAMS_NAME}[] = {{\n"
+
+    link_params = []
+    for coap_resource in coap_resources:
+        link_params.append(INDENT + generate_coap_link_param(coap_resource))
+
+    result += ",\n".join(link_params)
+    result += "\n}"
+    return result
+
+
 def generate_init_function() -> str:
     result = "void wot_td_coap_config_init(void)\n"
     result += "{\n"
@@ -215,6 +232,7 @@ def assemble_results(coap_jsons: list, thing_jsons: list) -> list:
     result_elements.append(generate_includes(coap_resources))
     result_elements.append(generate_coap_handlers(coap_resources))
     result_elements.append(write_coap_resources(coap_resources))
+    result_elements.append(generate_coap_link_params(coap_resources))
     result_elements.append(generate_coap_listener())
     result_elements.append(generate_init_function())
 

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -263,8 +263,8 @@ def assemble_results(coap_jsons: list, thing_jsons: list) -> list:
 def get_result():
     coap_jsons = [get_wot_json(affordance_file)
                   for affordance_file in AFFORDANCES_FILES]
-    thing_jsons = [get_wot_json(
-        thing_file, validation_function=validate_thing_json) for thing_file in THING_FILES]
+    thing_jsons = [get_wot_json(thing_file, validation_function=validate_thing_json)
+                   for thing_file in THING_FILES]
 
     result_elements = assemble_results(coap_jsons, thing_jsons)
 

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -237,7 +237,7 @@ def generate_coap_link_params(coap_resources: list):
 
 
 def generate_init_function() -> str:
-    result = "void wot_td_coap_config_init(void)\n"
+    result = "void wot_td_coap_init(void)\n"
     result += "{\n"
     result += INDENT + f"gcoap_register_listener(&{COAP_LISTENER_NAME});\n"
     result += "}\n"

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -12,8 +12,8 @@ AFFORDANCES_FILES = [".coap_affordances.json", ]
 THING_FILES = [".thing.json", ]
 SEPERATOR = "\n\n"
 INDENT = "    "
-COAP_LISTENER_NAME = "_coap_listener"
 COAP_RESOURCES_NAME = "_wot_coap_resources"
+COAP_LISTENER_NAME = "_wot_coap_listener"
 COAP_LINK_PARAMS_NAME = "_wot_link_params"
 COAP_LINK_ENCODER_NAME = "_wot_encode_link"
 

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -204,9 +204,9 @@ def generate_coap_handlers(coap_resources: list) -> str:
             handler += f'if (method_flag == {method})\n'
             handler += INDENT
             handler += "{\n"
-            handler += INDENT + INDENT
+            handler += INDENT * 2
             handler += 'puts("Hi.");\n'
-            handler += INDENT + INDENT
+            handler += INDENT * 2
             handler += 'return gcoap_response(pdu, buf, len, COAP_CODE_CHANGED);\n'
             handler += INDENT
             handler += "}\n"

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -4,28 +4,20 @@ import argparse
 import sys
 
 AFFORDANCE_TYPES = ['properties', 'actions', 'events']
+CURRENT_DIRECTORY = os.getcwd()
+CONFIG_DIRECTORY = f"{CURRENT_DIRECTORY}/config"
+THING_DESCRIPTION_DIRECTORY = f"{CONFIG_DIRECTORY}/wot_td"
+RESULT_FILE = f"{CURRENT_DIRECTORY}/result.c"
+AFFORDANCES_FILES = [".coap_affordances.json", ]
+THING_FILES = [".thing.json", ]
+SEPERATOR = "\n\n"
+INDENT = "    "
+COAP_LISTENER_NAME = "_coap_listener"
 
-current_directory = os.getcwd()
-result_file = current_directory + "/result.c"
-result = ""
-coap_jsons = []
-thing_jsons = []
-multiple_usage = {
-    "properties": [],
-    "actions": [],
-    "events": []
-}
-coap_affordances = {
-    "properties": [],
-    "actions": [],
-    "events": []
-}
+DEFAULT_DEPENDENCIES = ['<stdint.h>', '<stdio.h>', '<stdlib.h>',
+                        '<string.h>', '"net/gcoap.h"', '"od.h"', '"fmt.h"', ]
 
-parser = argparse.ArgumentParser(description='Web of Things helper script')
-parser.add_argument('--board', help='Define used board')
-parser.add_argument('--saul', action='store_true',
-                    help='Define if WoT TD SAUL is used')
-parser.add_argument('--security', help='Define what security is used')
+used_affordance_keys = []
 
 
 def dict_raise_on_duplicates(ordered_pairs):
@@ -39,14 +31,8 @@ def dict_raise_on_duplicates(ordered_pairs):
     return d
 
 
-def add_content(content):
-    global result
-    result += content
-
-
-def write_to_c_file(content):
-    global result
-    f = open(result_file, "w")
+def write_to_c_file(result):
+    f = open(RESULT_FILE, "w")
     f.write(result)
     f.close()
 
@@ -65,36 +51,34 @@ def validate_thing_json(thing_json):
     assert thing_json['defaultLang'], "ERROR: name in thing.json missing"
 
 
-def write_coap_resources(coap_resources):
-    add_content("const coap_resource_t _coap_resources[] = {\n")
+def write_coap_resources(coap_resources: list) -> str:
     sorted_resources = sorted(coap_resources, key=lambda k: k['href'])
+
+    result = "const coap_resource_t _coap_resources[] = {\n"
     for resource in sorted_resources:
-        add_content(f'    {{"{resource["href"]}", ')
-        for index, method in enumerate(resource['methods']):
-            if index > 0:
-                add_content(" | ")
-            add_content(method)
-        add_content(", " + resource['handler'] + ", NULL},\n")
+        result += f'    {{"{resource["href"]}", '
+        result += " | ".join(resource['methods'])
+        result += ", " + resource['handler'] + ", NULL},\n"
+    result += "};"
 
-    add_content("};")
+    return result
 
 
-def generate_coap_resources():
+def generate_coap_resources(coap_jsons: list) -> str:
     coap_resources = []
     for coap_json in coap_jsons:
         for affordance_type in AFFORDANCE_TYPES:
             for affordance_name, affordance in coap_json[affordance_type].items():
                 assert_unique_affordance(affordance_name)
-                multiple_usage[affordance_type].append(affordance_name)
+                used_affordance_keys.append(affordance_name)
                 forms = affordance["forms"]
                 resources = extract_coap_resources(forms)
                 coap_resources.extend(resources)
-    write_coap_resources(coap_resources)
+    return coap_resources
 
 
 def assert_unique_affordance(affordance_name: str):
-    for defined_affordances in multiple_usage.values():
-        assert affordance_name not in defined_affordances, "ERROR: Each coap affordance has to be unique"
+    assert affordance_name not in used_affordance_keys, "ERROR: Each coap affordance name has to be unique"
 
 
 def extract_coap_resources(resources: list) -> list:
@@ -129,37 +113,133 @@ def extract_coap_resources(resources: list) -> list:
     return resource_list
 
 
-if __name__ == '__main__':
-    args = parser.parse_args()
+def get_wot_json(file: str, directory=THING_DESCRIPTION_DIRECTORY, validation_function=None) -> str:
+    path = f'{directory}/{file}'
+    try:
+        f = open(path)
+        wot_json = json.loads(f.read())
+        if validation_function is not None:
+            validation_function(wot_json)
+    except IOError:
+        print(f"ERROR reading {path} is missing")
+        sys.exit(0)
+    except json.decoder.JSONDecodeError:
+        print(f"ERROR: json in {path} is not valid")
+        sys.exit(0)
+    finally:
+        f.close()
+
+    return wot_json
+
+
+def parse_command_line_arguments() -> list:
+    parser = argparse.ArgumentParser(description='Web of Things helper script')
+    parser.add_argument('--board', help='Define used board')
+    parser.add_argument('--saul', action='store_true',
+                        help='Define if WoT TD SAUL is used')
+    parser.add_argument('--security', help='Define what security is used')
+    return parser.parse_args()
+
+
+def assert_command_line_arguments(args):
     assert args.board, "ERROR: Argument board has to be defined"
     assert args.security, "ERROR: Argument security has to be defined"
 
-    thing_definiton = f"{current_directory}/config/wot_td/.thing.json"
-    try:
-        f = open(thing_definiton)
-        thing_json = json.loads(f.read())
-        validate_thing_json(thing_json)
-    except IOError:
-        print(f"ERROR: Thing definition in {thing_definiton} is missing")
-        sys.exit(0)
-    except json.decoder.JSONDecodeError:
-        print(f"ERROR: json in {thing_definiton} is not valid")
-        sys.exit(0)
-    finally:
-        f.close()
 
-    coap_affordances = f"{current_directory}/config/wot_td/.coap_affordances.json"
-    try:
-        f = open(coap_affordances)
-        coap_json = json.loads(
-            f.read(), object_pairs_hook=dict_raise_on_duplicates)
-        coap_jsons.append(coap_json)
-    except IOError:
-        print(f"INFO: Coap definition in {coap_affordances} not present")
-    except json.decoder.JSONDecodeError:
-        print(f"ERROR: json in {coap_affordances} is not valid")
-        sys.exit(0)
-    finally:
-        f.close()
-    generate_coap_resources()
+def generate_includes(coap_resources: list) -> str:
+    dependencies = DEFAULT_DEPENDENCIES
+
+    dependencies = [f'#include {dependency}' for dependency in dependencies]
+    return "\n".join(dependencies)
+
+
+def generate_coap_listener() -> str:
+    result = f"static gcoap_listener_t {COAP_LISTENER_NAME} = {{\n"
+    result += INDENT + "&_coap_resources[0],\n"
+    result += INDENT + "ARRAY_SIZE(_coap_resources),\n"
+    result += INDENT + "NULL,\n"
+    result += INDENT + "NULL,\n"
+    result += INDENT + "NULL\n"
+    result += "};"
+
+    return result
+
+
+def generate_coap_handlers(coap_resources: list) -> str:
+    handlers = []
+
+    for resource in coap_resources:
+        handler = f"static ssize_t {resource['handler']}(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)\n"
+        handler += "{\n"
+        handler += INDENT
+        handler += "(void)ctx;\n"
+        handler += INDENT
+        handler += 'unsigned method_flag = coap_method2flag(coap_get_code_detail(pdu));\n\n'
+
+        for index, method in enumerate(resource['methods']):
+            handler += INDENT
+            if index > 0:
+                handler += 'else '
+            handler += f'if (method_flag == {method})\n'
+            handler += INDENT
+            handler += "{\n"
+            handler += INDENT + INDENT
+            handler += 'puts("Hi.");\n'
+            handler += INDENT + INDENT
+            handler += 'return gcoap_response(pdu, buf, len, COAP_CODE_CHANGED);\n'
+            handler += INDENT
+            handler += "}\n"
+
+        handler += "\n" + INDENT
+        handler += "return 0;\n"
+        handler += "}"
+
+    handlers.append(handler)
+
+    return SEPERATOR.join(handlers)
+
+
+def generate_init_function() -> str:
+    result = "void wot_td_coap_config_init(void)\n"
+    result += "{\n"
+    result += INDENT + f"gcoap_register_listener(&{COAP_LISTENER_NAME});\n"
+    result += "}\n"
+
+    return result
+
+
+def assemble_results(coap_jsons: list, thing_jsons: list) -> list:
+    coap_resources = generate_coap_resources(coap_jsons)
+
+    result_elements = []
+    result_elements.append(generate_includes(coap_resources))
+    result_elements.append(generate_coap_handlers(coap_resources))
+    result_elements.append(write_coap_resources(coap_resources))
+    result_elements.append(generate_coap_listener())
+    result_elements.append(generate_init_function())
+
+    return result_elements
+
+
+def get_result():
+    coap_jsons = [get_wot_json(affordance_file)
+                  for affordance_file in AFFORDANCES_FILES]
+    thing_jsons = [get_wot_json(
+        thing_file, validation_function=validate_thing_json) for thing_file in THING_FILES]
+
+    result_elements = assemble_results(coap_jsons, thing_jsons)
+
+    return SEPERATOR.join(result_elements)
+
+
+def main():
+    args = parse_command_line_arguments()
+    assert_command_line_arguments(args)
+
+    result = get_result()
+    write_to_c_file(result)
     print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/wot_coap_generation/generate.py
+++ b/tests/wot_coap_generation/generate.py
@@ -13,6 +13,7 @@ THING_FILES = [".thing.json", ]
 SEPERATOR = "\n\n"
 INDENT = "    "
 COAP_LISTENER_NAME = "_coap_listener"
+COAP_RESOURCES_NAME = "_wot_coap_resources"
 COAP_LINK_PARAMS_NAME = "_wot_link_params"
 COAP_LINK_ENCODER_NAME = "_wot_encode_link"
 
@@ -74,7 +75,7 @@ def validate_thing_json(thing_json):
 def write_coap_resources(coap_resources: list) -> str:
     sorted_resources = sorted(coap_resources, key=lambda k: k['href'])
 
-    result = "const coap_resource_t _coap_resources[] = {\n"
+    result = f"const coap_resource_t {COAP_RESOURCES_NAME}[] = {{\n"
     for resource in sorted_resources:
         result += f'    {{"{resource["href"]}", '
         result += " | ".join(resource['methods'])
@@ -175,8 +176,8 @@ def generate_includes(coap_resources: list) -> str:
 
 def generate_coap_listener() -> str:
     result = f"static gcoap_listener_t {COAP_LISTENER_NAME} = {{\n"
-    result += INDENT + "&_coap_resources[0],\n"
-    result += INDENT + "ARRAY_SIZE(_coap_resources),\n"
+    result += INDENT + f"&{COAP_RESOURCES_NAME}[0],\n"
+    result += INDENT + f"ARRAY_SIZE({COAP_RESOURCES_NAME}),\n"
     result += INDENT + f"{COAP_LINK_ENCODER_NAME},\n"
     result += INDENT + "NULL,\n"
     result += INDENT + "NULL\n"

--- a/tests/wot_coap_generation/result.c
+++ b/tests/wot_coap_generation/result.c
@@ -1,0 +1,59 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "net/gcoap.h"
+#include "od.h"
+#include "fmt.h"
+
+static ssize_t _led_toggle_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)
+{
+    (void)ctx;
+    unsigned method_flag = coap_method2flag(coap_get_code_detail(pdu));
+
+    if (method_flag == COAP_POST)
+    {
+        puts("Hi.");
+        return gcoap_response(pdu, buf, len, COAP_CODE_CHANGED);
+    }
+
+    return 0;
+}
+
+const coap_resource_t _wot_coap_resources[] = {
+    {"/led/toggle", COAP_POST, _led_toggle_handler, NULL},
+};
+
+static const char *_wot_link_params[] = {
+    NULL
+}
+
+static gcoap_listener_t _wot_coap_listener = {
+    &_wot_coap_resources[0],
+    ARRAY_SIZE(_wot_coap_resources),
+    _wot_encode_link,
+    NULL,
+    NULL
+};
+
+static ssize_t _wot_encode_link(const coap_resource_t *resource, char *buf,
+                            size_t maxlen, coap_link_encoder_ctx_t *context) {
+    ssize_t res = gcoap_encode_link(resource, buf, maxlen, context);
+    if (res > 0) {
+        if (_wot_link_params[context->link_pos]
+                && (strlen(_wot_link_params[context->link_pos]) < (maxlen - res))) {
+            if (buf) {
+                memcpy(buf+res, _wot_link_params[context->link_pos],
+                       strlen(_wot_link_params[context->link_pos]));
+            }
+            return res + strlen(_wot_link_params[context->link_pos]);
+        }
+    }
+
+    return res;
+}
+
+void wot_td_coap_init(void)
+{
+    gcoap_register_listener(&_wot_coap_listener);
+}


### PR DESCRIPTION
After reworking some more of the script's structure, it now generates all necessary parts for the `result.c` file to actually work (inclusion of necessary header files, declaration of handler functions, listener registration, encoding of link parameters). However, it still is mostly the basis on which further commits can build upon. 

I think especially the handler generation deserves attention in this respect as is the most important link between the TD and the thing itself. I think that this is also the place where the connection to SAUL could or should be established. Maybe this could actually be realized relatively easy by adding a corresponding parameter (something like `device_name` to the forms of an affordance in its JSON file and then let SAUL figure out the rest. But I still have to research more to get a feeling how this problem could be solved as elegant as possible. For now, I am looking forward to you feedback!