### PR TITLE
Pass base URI struct seperately to serialization function

### DIFF
--- a/sys/include/net/wot/serialization.h
+++ b/sys/include/net/wot/serialization.h
@@ -11,6 +11,6 @@ typedef struct {
 
 int wot_td_serialize_thing(
         wot_td_serialize_receiver_t receiver, wot_td_thing_t *thing,
-        wot_td_ser_slicer_t *slicer);
+        wot_td_uri_t *base, wot_td_ser_slicer_t *slicer);
 
 #endif //WOT_SERIALIZATION_H

--- a/sys/include/net/wot/serialization.h
+++ b/sys/include/net/wot/serialization.h
@@ -11,6 +11,6 @@ typedef struct {
 
 int wot_td_serialize_thing(
         wot_td_serialize_receiver_t receiver, wot_td_thing_t *thing,
-        wot_td_uri_t *base, wot_td_ser_slicer_t *slicer);
+        wot_td_ser_slicer_t *slicer);
 
 #endif //WOT_SERIALIZATION_H

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -28,8 +28,6 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
 
 wot_td_thing_t wot_thing;
 
-// static char wot_thing_addr[IPV6_ADDR_MAX_STR_LEN + 1];
-
 const char wot_td_coap_schema[] = "coap://";
 
 //Todo: Implement CoAP RDF bindings.

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -100,6 +100,48 @@ void _wot_td_coap_ser_receiver(const char *c){
     _wot_td_coap_plen += coap_blockwise_put_char(&_wot_td_coap_slicer, _wot_td_coap_buf+_wot_td_coap_plen, (char) *c);
 }
 
+static int get_base_ip_address(char *address_as_string){
+    const int MAX_ADRESSES = 5;
+    netif_t* interface = netif_iter(NULL);
+    ipv6_addr_t* local_address = NULL;
+    ipv6_addr_t* ula_address = NULL;
+
+    while(interface != NULL) {
+        ipv6_addr_t adresses[MAX_ADRESSES];
+        netif_get_opt(interface, NETOPT_IPV6_ADDR, 0, adresses, sizeof(adresses));
+        for (int i = 0; i < MAX_ADRESSES; i++)
+        {
+            ipv6_addr_t* current_address = &adresses[i];
+
+            if (current_address == NULL) {
+                break;
+            }
+            if (ipv6_addr_is_global(current_address)) {
+                ipv6_addr_to_str(address_as_string, current_address, IPV6_ADDR_MAX_STR_LEN);
+                return 0;
+            }
+            else if (ipv6_addr_is_unique_local_unicast(current_address)) {
+                ula_address = current_address;
+            }
+            else if (ipv6_addr_is_unique_local_unicast(current_address)) {
+                local_address = current_address;
+            }
+        }
+        interface = netif_iter(interface);
+    }
+
+    if (ula_address != NULL) {
+        ipv6_addr_to_str(address_as_string, ula_address, IPV6_ADDR_MAX_STR_LEN);
+        return 0;
+    }
+    else if (local_address != NULL) {
+        ipv6_addr_to_str(address_as_string, local_address, IPV6_ADDR_MAX_STR_LEN);
+        return 0;
+    }
+    address_as_string = "example.org";
+    return -1;
+}
+
 static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx){
     (void)ctx;
 
@@ -117,10 +159,14 @@ static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
             .end = _wot_td_coap_slicer.end,
     };
 
+    char address_as_string[IPV6_ADDR_MAX_STR_LEN];
+    get_base_ip_address(address_as_string);
+    puts(address_as_string); // For Debugging
+
     wot_td_uri_t _wot_thing_base = {
             .schema = wot_td_coap_schema,
-            .value = "example.org", // TODO: Get URI from CoAP packet (or somewhere else)
-    };
+            .value = address_as_string,
+    };    
 
     wot_thing.base = &_wot_thing_base;
 

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -101,8 +101,8 @@ void _wot_td_coap_ser_receiver(const char *c){
 static int get_base_ip_address(ipv6_addr_t *res) {
     const int MAX_ADRESSES_TO_CHECK = 5;
     netif_t* interface = NULL;
-    ipv6_addr_t local_address = {{0}};
-    ipv6_addr_t ula_address = {{0}};
+    ipv6_addr_t local_address = {0};
+    ipv6_addr_t ula_address = {0};
     bool link_local_found = false;
     bool ula_found = false;
 

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -28,14 +28,9 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
 
 wot_td_thing_t wot_thing;
 
-static char wot_thing_addr[IPV6_ADDR_MAX_STR_LEN + 1];
+// static char wot_thing_addr[IPV6_ADDR_MAX_STR_LEN + 1];
 
 const char wot_td_coap_schema[] = "coap://";
-
-wot_td_uri_t _wot_thing_id = {
-        .schema = wot_td_coap_schema,
-        .value = wot_thing_addr,
-};
 
 //Todo: Implement CoAP RDF bindings.
 //See: https://github.com/w3c/wot-binding-templates/issues/97
@@ -122,7 +117,12 @@ static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
             .end = _wot_td_coap_slicer.end,
     };
 
-    wot_td_serialize_thing((wot_td_serialize_receiver_t) &_wot_td_coap_ser_receiver, &wot_thing, &_wot_td_slicer);
+    wot_td_uri_t _wot_thing_base = {
+            .schema = wot_td_coap_schema,
+            .value = "example.org", // TODO: Get URI from CoAP packet
+    };
+
+    wot_td_serialize_thing((wot_td_serialize_receiver_t) &_wot_td_coap_ser_receiver, &wot_thing, &_wot_thing_base, &_wot_td_slicer);
 
     coap_block2_finish(&_wot_td_coap_slicer);
 

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -138,7 +138,6 @@ static int get_base_ip_address(char *address_as_string){
         ipv6_addr_to_str(address_as_string, local_address, IPV6_ADDR_MAX_STR_LEN);
         return 0;
     }
-    address_as_string = "example.org";
     return -1;
 }
 
@@ -160,7 +159,7 @@ static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
     };
 
     char address_as_string[IPV6_ADDR_MAX_STR_LEN];
-    get_base_ip_address(address_as_string);
+    get_base_ip_address(address_as_string); // TODO: Check return value
     puts(address_as_string); // For Debugging
 
     wot_td_uri_t _wot_thing_base = {

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -123,7 +123,7 @@ static int get_base_ip_address(char *address_as_string){
             else if (ipv6_addr_is_unique_local_unicast(current_address)) {
                 ula_address = current_address;
             }
-            else if (ipv6_addr_is_unique_local_unicast(current_address)) {
+            else if (ipv6_addr_is_link_local(current_address)) {
                 local_address = current_address;
             }
         }

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -122,7 +122,9 @@ static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
             .value = "example.org", // TODO: Get URI from CoAP packet
     };
 
-    wot_td_serialize_thing((wot_td_serialize_receiver_t) &_wot_td_coap_ser_receiver, &wot_thing, &_wot_thing_base, &_wot_td_slicer);
+    wot_thing.base = &_wot_thing_base;
+
+    wot_td_serialize_thing((wot_td_serialize_receiver_t) &_wot_td_coap_ser_receiver, &wot_thing, &_wot_td_slicer);
 
     coap_block2_finish(&_wot_td_coap_slicer);
 

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -119,7 +119,7 @@ static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
 
     wot_td_uri_t _wot_thing_base = {
             .schema = wot_td_coap_schema,
-            .value = "example.org", // TODO: Get URI from CoAP packet
+            .value = "example.org", // TODO: Get URI from CoAP packet (or somewhere else)
     };
 
     wot_thing.base = &_wot_thing_base;

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -105,11 +105,12 @@ static int get_base_ip_address(ipv6_addr_t *res) {
     ipv6_addr_t ula_address = {0};
     bool link_local_found = false;
     bool ula_found = false;
+    int netres;
 
     while ((interface = netif_iter(interface)) != NULL) {
         ipv6_addr_t adresses[MAX_ADRESSES_TO_CHECK];
-        netif_get_opt(interface, NETOPT_IPV6_ADDR, 0, adresses, sizeof(adresses));
-        for (int i = 0; i < MAX_ADRESSES_TO_CHECK; i++)
+        netres = netif_get_opt(interface, NETOPT_IPV6_ADDR, 0, adresses, sizeof(adresses));
+        for (unsigned i = 0; i < (netres / sizeof(ipv6_addr_t)); i++)
         {
             ipv6_addr_t* current_address = &adresses[i];
 

--- a/sys/net/wot/core/serialization.c
+++ b/sys/net/wot/core/serialization.c
@@ -1,9 +1,10 @@
-#include "net/wot.h"
-#include "net/wot/serialization.h"
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+#include "net/wot.h"
+#include "net/wot/serialization.h"
 
 const char wot_td_ser_obj_context_key[] = "@context";
 const char wot_td_ser_w3c_context_value[] = "https://www.w3.org/2019/wot/td/v1";

--- a/sys/net/wot/core/serialization.c
+++ b/sys/net/wot/core/serialization.c
@@ -1209,7 +1209,7 @@ int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t 
         _serialize_link_array(receiver, thing->links, slicer);
     }
 
-    assert(thing->support != NULL);
+    assert(thing->base != NULL);
     _previous_prop_check(receiver, has_previous_prop, slicer);
     _wot_td_fill_json_obj_key(receiver, wot_td_ser_base_obj_key, sizeof(wot_td_ser_base_obj_key)-1, slicer);
     _wot_td_fill_json_uri(receiver, thing->base, slicer);

--- a/sys/net/wot/core/serialization.c
+++ b/sys/net/wot/core/serialization.c
@@ -1,5 +1,6 @@
 #include "net/wot.h"
 #include "net/wot/serialization.h"
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -1207,6 +1208,7 @@ int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t 
         _serialize_link_array(receiver, thing->links, slicer);
     }
 
+    assert(base != NULL);
     _previous_prop_check(receiver, has_previous_prop, slicer);
     _wot_td_fill_json_obj_key(receiver, wot_td_ser_base_obj_key, sizeof(wot_td_ser_base_obj_key)-1, slicer);
     _wot_td_fill_json_uri(receiver, base, slicer);

--- a/sys/net/wot/core/serialization.c
+++ b/sys/net/wot/core/serialization.c
@@ -1136,7 +1136,7 @@ void _serialize_link_array(wot_td_serialize_receiver_t receiver, wot_td_link_t *
     _wot_td_fill_json_receiver(receiver, "]", 1, slicer);
 }
 
-int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t *thing, wot_td_uri_t *base, wot_td_ser_slicer_t *slicer){
+int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t *thing, wot_td_ser_slicer_t *slicer){
     //Todo: Check for all necessary properties, before continue processing
 
     bool has_previous_prop = false;
@@ -1209,10 +1209,10 @@ int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t 
         _serialize_link_array(receiver, thing->links, slicer);
     }
 
-    assert(base != NULL);
+    assert(thing->support != NULL);
     _previous_prop_check(receiver, has_previous_prop, slicer);
     _wot_td_fill_json_obj_key(receiver, wot_td_ser_base_obj_key, sizeof(wot_td_ser_base_obj_key)-1, slicer);
-    _wot_td_fill_json_uri(receiver, base, slicer);
+    _wot_td_fill_json_uri(receiver, thing->base, slicer);
 
     if(thing->support != NULL){
         _wot_td_fill_json_receiver(receiver, ",", 1, slicer);

--- a/sys/net/wot/core/serialization.c
+++ b/sys/net/wot/core/serialization.c
@@ -1134,7 +1134,7 @@ void _serialize_link_array(wot_td_serialize_receiver_t receiver, wot_td_link_t *
     _wot_td_fill_json_receiver(receiver, "]", 1, slicer);
 }
 
-int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t *thing, wot_td_ser_slicer_t *slicer){
+int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t *thing, wot_td_uri_t *base, wot_td_ser_slicer_t *slicer){
     //Todo: Check for all necessary properties, before continue processing
 
     bool has_previous_prop = false;
@@ -1207,11 +1207,9 @@ int wot_td_serialize_thing(wot_td_serialize_receiver_t receiver, wot_td_thing_t 
         _serialize_link_array(receiver, thing->links, slicer);
     }
 
-    if(thing->base != NULL){
-        _previous_prop_check(receiver, has_previous_prop, slicer);
-        _wot_td_fill_json_obj_key(receiver, wot_td_ser_base_obj_key, sizeof(wot_td_ser_base_obj_key)-1, slicer);
-        _wot_td_fill_json_uri(receiver, thing->base, slicer);
-    }
+    _previous_prop_check(receiver, has_previous_prop, slicer);
+    _wot_td_fill_json_obj_key(receiver, wot_td_ser_base_obj_key, sizeof(wot_td_ser_base_obj_key)-1, slicer);
+    _wot_td_fill_json_uri(receiver, base, slicer);
 
     if(thing->support != NULL){
         _wot_td_fill_json_receiver(receiver, ",", 1, slicer);

--- a/tests/wot_coap_generation/Makefile
+++ b/tests/wot_coap_generation/Makefile
@@ -42,8 +42,7 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_icmpv6_error
 USEMODULE += gnrc_icmpv6_echo
 # Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_sixlowpan_border_router_default
+USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_udp
 # Add a routing protocol
 USEMODULE += gnrc_rpl

--- a/tests/wot_coap_generation/Makefile
+++ b/tests/wot_coap_generation/Makefile
@@ -15,7 +15,7 @@ USEMODULE += xtimer
 ifeq ($(BOARD),esp32-wroom-32)
 # ESP wifi configuration
 USEMODULE += esp_wifi
-WIFI_SSID?=\"Your\ SSID"
+WIFI_SSID?=\"Your\ SSID\"
 WIFI_PASS?=\"Your\ Password\"
 CFLAGS += -DESP_WIFI_SSID=$(WIFI_SSID)
 CFLAGS += -DESP_WIFI_PASS=$(WIFI_PASS)

--- a/tests/wot_coap_generation/led_controls.c
+++ b/tests/wot_coap_generation/led_controls.c
@@ -24,17 +24,23 @@ char* get_led_status(void) {
 
 void turn_on_led(void) {
     led_on = true;
+    #ifdef LED_GPIO
     gpio_set(LED_GPIO);
+    #endif
 }
 
 void turn_off_led(void) {
     led_on = false;
+    #ifdef LED_GPIO
     gpio_clear(LED_GPIO);
+    #endif
 }
 
 void toggle_led(void) {
     led_on = !led_on;
+    #ifdef LED_GPIO
     gpio_toggle(LED_GPIO);
+    #endif
 }
 
 // Toggle LED (default GPIO: 33, cf. Makefile)
@@ -69,8 +75,10 @@ int led_cmd(int argc, char **argv) {
 }
 
 void led_cmd_init(void) {
+    #ifdef LED_GPIO
     gpio_init(LED_GPIO, GPIO_OUT);
     gpio_set(LED_GPIO);
+    #endif
     led_on = true;
 }
 


### PR DESCRIPTION
This PR tries to lay the groundwork for passing the base URI from a CoAP packet to the serialization function. As soon as #8 (or a similar solution) is merged, the IP address a `GET /.well-known/wot-thing-description` request was sent to should be able to be determined, extracted from the CoAP packet, and added to the TD. Feedback is very much appreciated :)