### PR TITLE
Add "All CoAP Nodes" to net interfaces

### DIFF
--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -18,6 +18,8 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
 wot_td_thing_t wot_thing;
 
 const char wot_td_coap_schema[] = "coap://";
+const char coap_multicast_addr_str[] = "ff02::fd";
+static ipv6_addr_t coap_multicast_addr = {0};
 
 //Todo: Implement CoAP RDF bindings.
 //See: https://github.com/w3c/wot-binding-templates/issues/97
@@ -248,5 +250,10 @@ void wot_td_coap_server_init(void)
     wot_td_coap_config_init(&wot_thing);
 
     gcoap_init();
+    gnrc_netif_t* netif = NULL;
+    while (gnrc_netif_iter(netif) != NULL) {
+        gnrc_netif_addr_from_str(coap_multicast_addr_str, (uint8_t *) &coap_multicast_addr);
+        gnrc_netif_ipv6_group_join(netif, &coap_multicast_addr);
+    }
     gcoap_register_listener(&_wot_td_gcoap_listener);
 }


### PR DESCRIPTION
@Citrullin For one of my use cases it would be nice to let our WoT devices join the "All CoAP nodes" IPv6 multicast group (see [RFC 7252, section 12.8](https://datatracker.ietf.org/doc/html/rfc7252#section-12.8)). Maybe you can have a look on this rather old commit to see if this is the right place to call the `gnrc_netif_ipv6_group_join` function. 

(I am wondering if Gcoap should actually join this multicast group by default?)