### PR TITLE
Add WoT content format

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -152,6 +152,7 @@ extern "C" {
 #define COAP_FORMAT_SENSML_EXI              (115)
 #define COAP_FORMAT_SENML_XML               (310)
 #define COAP_FORMAT_SENSML_XML              (311)
+#define COAP_FORMAT_WOT_TD                  (432)
 /** @} */
 
 /**

--- a/sys/net/wot/coap/coap.c
+++ b/sys/net/wot/coap/coap.c
@@ -139,7 +139,7 @@ static ssize_t _wot_td_coap_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
     coap_block2_init(pdu, &_wot_td_coap_slicer);
 
     gcoap_resp_init(pdu, _wot_td_coap_buf, len, COAP_CODE_CONTENT);
-    coap_opt_add_format(pdu, COAP_FORMAT_JSON);
+    coap_opt_add_format(pdu, COAP_FORMAT_WOT_TD);
     coap_opt_add_block2(pdu, &_wot_td_coap_slicer, 1);
     _wot_td_coap_plen = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
 


### PR DESCRIPTION
In the [WoT TD specification](https://www.w3.org/TR/wot-thing-description/#identification) a content-type number 432 was introduced that should be used to identify a TD. This PR updates both the CoAP header files and our implementation accordingly.